### PR TITLE
17_AWSテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'rails-i18n', '~> 6.0'
 gem 'devise-i18n'
 gem 'activeadmin'
 gem 'devise-bootstrap-views'
+gem 'redcarpet'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -273,6 +274,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -2,5 +2,9 @@ class AwsTextsController < ApplicationController
   def index
     @aws_texts = AwsText.order(:id)
   end
+
+  def show
+    @aws_text = AwsText.find(params[:id])
+  end
   
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,20 @@
 module ApplicationHelper
+  def markdown(text)
+    unless @markdown
+      options = {
+        hard_wrap: true
+      }
+      extensions = {
+        no_intra_emphasis: true,
+        tables: true,
+        fenced_code_blocks: true,
+        autolink: true,
+        quote: true
+      }
+      renderer = Redcarpet::Render::HTML.new(options)
+      @markdown = Redcarpet::Markdown.new(renderer, extensions)
+    end
+
+    @markdown.render(text).html_safe
+  end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -17,13 +17,13 @@
   @extend .alert-danger;
 }
 
-// ↓ログイン周りの設定
+// ログイン周りの設定（開始）
 .login-container {
   max-width: 576px;
   margin: 0 auto;
   padding-top: 152px;
 }
-// ↑ログイン周りの設定
+// ↑ログイン周りの設定（終了）
 
 body {
   padding-top: 56px;
@@ -109,3 +109,11 @@ body {
 // AWS関連（タスク16で追加）ここまで
 
 
+// AWSテキスト教材の詳細ページ（開始）
+.aws_detail_container {
+  max-width: 700px;
+  font-size: 17px;
+  margin: 0 auto;
+  line-height: 1.9em;
+}
+// AWSテキスト教材の詳細ページ（終了）

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -12,7 +12,7 @@
       <tbody>
         <% @aws_texts.each do |aws_text| %>
           <tr>
-            <td><%= aws_text.id %></td> <td><%= aws_text.title %></td>
+            <td><%= aws_text.id %></td> <td><%= link_to aws_text.title, aws_text_path(aws_text.id) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,4 @@
+<div class="aws_detail_container">
+  <h2><%= markdown(@aws_text.title) %></h2>
+  <p><%= markdown(@aws_text.content) %></p>
+</div>


### PR DESCRIPTION
## 内容
- AWSテキスト教材一覧ページに詳細ページへのリンクを追加
- Markdownに対応したAWSテキスト教材の詳細ページの作成

## 参考資料
https://qiita.com/shimoch/items/466ed5cc5c232e58b34f